### PR TITLE
Make archive buttons only accessible by admins

### DIFF
--- a/client/src/components/EditItem.tsx
+++ b/client/src/components/EditItem.tsx
@@ -430,12 +430,7 @@ function EditItem(props: {
                   <DeleteButton
                     id={props.id}
                     fetchItems={props.fetchItems}
-                    disabled={
-                      props.item.approved &&
-                      !props.user.permissions.some((value) =>
-                        value.includes(PermissionType.ADMIN)
-                      )
-                    }
+                    disabled={props.item.approved && !isAdmin}
                   />
                   <div
                     style={{

--- a/client/src/components/EditItem.tsx
+++ b/client/src/components/EditItem.tsx
@@ -275,6 +275,10 @@ function EditItem(props: {
     );
   };
 
+  const isAdmin = props.user?.permissions.some((value) =>
+    value.includes(PermissionType.ADMIN)
+  );
+
   return (
     <Grid columns={1}>
       <Grid.Column>
@@ -438,16 +442,18 @@ function EditItem(props: {
                       width: "10px",
                     }}
                   />
-                  <ArchiveButton
-                    id={props.id}
-                    fetchItems={props.fetchItems}
-                    disabled={
-                      props.item.approved &&
-                      !props.user.permissions.some((value) =>
-                        value.includes(PermissionType.ADMIN)
-                      )
-                    }
-                  />
+                  {isAdmin ? (
+                    <ArchiveButton
+                      id={props.id}
+                      fetchItems={props.fetchItems}
+                      disabled={
+                        props.item.approved &&
+                        !props.user.permissions.some((value) =>
+                          value.includes(PermissionType.ADMIN)
+                        )
+                      }
+                    />
+                  ) : null}
                 </div>
                 <div
                   style={{

--- a/client/src/components/TableWidget.tsx
+++ b/client/src/components/TableWidget.tsx
@@ -73,6 +73,10 @@ const TableWidget = (props: {
       `${BuildingType.ALL}:${PermissionType.ADMIN}`
     ) ?? false;
 
+  const isAdmin = props.user?.permissions.some((value) =>
+    value.includes(PermissionType.ADMIN)
+  );
+
   return (
     <div>
       <div className="table-buttons">
@@ -81,7 +85,7 @@ const TableWidget = (props: {
             fetchItems={props.fetchItems}
             items={props.fixedItems}
           />
-          {!props.isArchivedItems ? (
+          {!props.isArchivedItems && isAdmin ? (
             <BulkArchiveButton
               fetchItems={props.fetchItems}
             ></BulkArchiveButton>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #175 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Check that user admins do not see the `BulkArchiveButton` and `ArchiveButton`
- [x] Check that admins still see the `BulkArchiveButton` and `ArchiveButton`

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version: 14.15.4
- Desktop/Mobile: Desktop
- Browser: Google Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
