### PR TITLE
convert flex display to grid for items

### DIFF
--- a/client/src/components/ItemCard.css
+++ b/client/src/components/ItemCard.css
@@ -2,8 +2,10 @@
   justify-content: space-between;
 
   /* Maybe switch this to display grid in the future, because last row is not spaced properly */
-  /* display: grid;
-  grid-template-columns: repeat(auto-fill, 400px); */
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  margin-bottom:20px;
 }
 .grid {
   grid-row: span 4; /* span 4 rows */
@@ -12,14 +14,9 @@
   grid-template-rows: subgrid; /* create a sub-grid with the 4 parent grid rows */
 }
 .card-wrapper {
-  width: 23%;
-  margin-bottom: 25px;
-  display:flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  display:grid;
   height: max-height;
-  padding-left: 10px;
-  padding-right: 10px;
+  gap:10px;
 }
 .card-wrapper-outer{
   height: max-height;

--- a/client/src/components/ItemCard.css
+++ b/client/src/components/ItemCard.css
@@ -1,32 +1,26 @@
 .ui.cards {
   justify-content: space-between;
-
-  /* Maybe switch this to display grid in the future, because last row is not spaced properly */
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 20px;
-  margin-bottom:20px;
+  margin-bottom: 20px;
 }
-.grid {
-  grid-row: span 4; /* span 4 rows */
-  display: grid;
-  /* magic is here */
-  grid-template-rows: subgrid; /* create a sub-grid with the 4 parent grid rows */
-}
+
 .card-wrapper {
-  display:grid;
+  display: grid;
   height: max-height;
-  gap:10px;
+  gap: 10px;
 }
-.card-wrapper-outer{
+
+.card-wrapper-outer {
   height: max-height;
 }
 
-.ui.card>.top-content {
+.ui.card > .top-content {
   padding: 30px;
 }
 
-.ui.card>.bottom-content {
+.ui.card > .bottom-content {
   text-align: left;
   padding: 30px;
 }
@@ -85,7 +79,7 @@ img.card-img {
   margin-top: 15px;
 }
 
-.show-image{
+.show-image {
   float: right;
-  margin: -15px!important;
+  margin: -15px !important;
 }

--- a/client/src/pages/Active.css
+++ b/client/src/pages/Active.css
@@ -1,9 +1,9 @@
-.ui.grid>.row {
+.ui.grid > .row {
   margin: 0;
   padding-bottom: 0;
 }
 
-.ui.grid>.row>.column {
+.ui.grid > .row > .column {
   margin-top: 0;
   padding-left: 80px;
   padding-right: 80px;
@@ -35,7 +35,7 @@
     padding-right: 20px;
   }
 
-  .ui.grid>.row>.column {
+  .ui.grid > .row > .column {
     padding-left: 20px;
     padding-right: 20px;
   }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The boxes in the last row were previously unaligned. Fixed this with grid instead of flex box.

Closes #197 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
