### PR TITLE
Fix page set to 1 on every edit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install dependencies
         run: npm i
         shell: bash

--- a/client/src/pages/Active.tsx
+++ b/client/src/pages/Active.tsx
@@ -111,7 +111,9 @@ function Active() {
       sort.direction ?? "descending"
     );
     setItemList(sorted);
-    setPage(1);
+    if (Math.ceil(sorted.length / 30) < page && page !== 1) {
+      setPage(page - 1);
+    }
   }, [itemListDefault, search, sort]);
 
   return (

--- a/client/src/pages/Archived.tsx
+++ b/client/src/pages/Archived.tsx
@@ -112,7 +112,9 @@ function Archived() {
       sort.direction ?? "descending"
     );
     setItemList(sorted);
-    setPage(1);
+    if (Math.ceil(sorted.length / 30) < page && page !== 1) {
+      setPage(page - 1);
+    }
   }, [itemListDefault, search, sort]);
 
   return (


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fix issue where the page resets to 1st page whenever an item is edited.

The current behavior is as follows: the page will stay the same unless there are no more items to show on the current page, in which case the page is set to the previous page (except when on the 1st page).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Tested when at the last page and removed all items until none on the page are left.
2. Tested when at the first page.
3. Tested when an item is removed from a random page.

